### PR TITLE
feature/release-docker-image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   goreleaser:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,22 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+
+      - name: Set up Go
         uses: actions/setup-go@v5
-      -
-        name: Run GoReleaser
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,7 +55,7 @@ docker_manifests:
 dockers:
   - image_templates:
       - "ghcr.io/calimapp/docdocgo:{{ .Tag }}-amd64"
-    dockerfile: release.Dockerfile
+    dockerfile: Dockerfile
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -67,7 +67,7 @@ dockers:
       - "--label=org.opencontainers.image.source={{.GitURL}}"
   - image_templates:
       - "ghcr.io/calimapp/docdocgo:{{ .Tag }}-arm64"
-    dockerfile: release.Dockerfile
+    dockerfile: Dockerfile
     use: buildx
     build_flag_templates:
       - "--pull"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,10 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
+    binary: docdocgo
 
 archives:
   - format: tar.gz
@@ -37,6 +41,43 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+
+docker_manifests:
+  - name_template: "ghcr.io/calimapp/docdocgo:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/calimapp/docdocgo:{{ .Tag }}-amd64"
+      - "ghcr.io/calimapp/docdocgo:{{ .Tag }}-arm64"
+  - name_template: "ghcr.io/calimapp/docdocgo:latest"
+    image_templates:
+      - "ghcr.io/calimapp/docdocgo:{{ .Tag }}-amd64"
+      - "ghcr.io/calimapp/docdocgo:{{ .Tag }}-arm64"
+
+dockers:
+  - image_templates:
+      - "ghcr.io/calimapp/docdocgo:{{ .Tag }}-amd64"
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - image_templates:
+      - "ghcr.io/calimapp/docdocgo:{{ .Tag }}-arm64"
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+    goarch: arm64
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,7 +28,7 @@ builds:
     binary: docdocgo
 
 archives:
-  - format: tar.gz
+  - formats: ["tar.gz"]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -55,7 +55,7 @@ docker_manifests:
 dockers:
   - image_templates:
       - "ghcr.io/calimapp/docdocgo:{{ .Tag }}-amd64"
-    dockerfile: Dockerfile
+    dockerfile: release.Dockerfile
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -67,7 +67,7 @@ dockers:
       - "--label=org.opencontainers.image.source={{.GitURL}}"
   - image_templates:
       - "ghcr.io/calimapp/docdocgo:{{ .Tag }}-arm64"
-    dockerfile: Dockerfile
+    dockerfile: release.Dockerfile
     use: buildx
     build_flag_templates:
       - "--pull"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,5 @@
-# Stage 1: Build stage
-FROM golang:1.24-alpine AS build
-
-# Set the working directory
-WORKDIR /app
-
-# Copy and download dependencies
-COPY go.mod go.sum ./
-RUN go mod download
-
-# Copy the source code
-COPY . .
-
-# Build the Go application
-RUN CGO_ENABLED=0 GOOS=linux go build -o docdocgo .
-
-# Stage 2: Final stage
 FROM scratch
 
-# Set the working directory
-WORKDIR /app
+COPY docdocgo /app/docdocgo
 
-# Copy the binary from the build stage
-COPY --from=build /app/docdocgo .
-
-# Set the entrypoint command
 ENTRYPOINT ["/app/docdocgo"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Stage 1: Build stage
+FROM golang:1.24-alpine AS build
+
+# Set the working directory
+WORKDIR /app
+
+# Copy and download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the source code
+COPY . .
+
+# Build the Go application
+RUN CGO_ENABLED=0 GOOS=linux go build -o docdocgo .
+
+# Stage 2: Final stage
+FROM scratch
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the binary from the build stage
+COPY --from=build /app/docdocgo .
+
+# Set the entrypoint command
+ENTRYPOINT ["/app/docdocgo"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker run -v $(pwd):/godoc -w /godoc ghcr.io/calimapp/docdocgo:latest --help
 ## Features
 
 ### High priority
-- [ ] Dockerize CLI, with auto docker deployment to docker hub
+- [x] Dockerize CLI, with auto docker deployment to docker hub
 - [ ] Refactor app in 2 separate modules parser and render
 
 ### Low priority

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ go install github.com/calimapp/docdocgo@latest
 
 <https://github.com/calimapp/docdocgo/releases>
 
+### With docker
+
+```sh
+docker run -v $(pwd):/godoc -w /godoc ghcr.io/calimapp/docdocgo:latest --help
+```
+
 ## Features
 
 ### High priority

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+
+COPY docdocgo /app/docdocgo
+ENTRYPOINT ["/app/docdocgo"]

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,4 +1,0 @@
-FROM scratch
-
-COPY docdocgo /app/docdocgo
-ENTRYPOINT ["/app/docdocgo"]


### PR DESCRIPTION
Docker images for `amd64` & `arm64` arch are published to **ghcr.io** by the release with `goreleaser` tool.
Dockerfile is only usable for the release purpose.